### PR TITLE
Update gwt/plugin, clean up pom, actually run checkstyle

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This configuration file was written by the eclipse-cs plugin configuration editor
+-->
+<!--
+Checkstyle-Configuration: GWT Checks
+Description:
+
+-->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+    <property name="severity" value="warning"/>
+    <module name="RegexpHeader">
+       <property name="fileExtensions" value="java"/>
+       <property name="severity" value="error"/>
+       <property name="header" value="^/\*[ ]*$\n^ \* Copyright 20(0[6789]|[12][0-9]) Google Inc\.$\n^ \*[ ]*$\n^ \* Licensed under the Apache License, Version 2\.0 \(the &quot;License&quot;\); you may not( use this file except)?$\n^ \* (use this file except )?in compliance with the License\. You may obtain a copy of( the License at)?$\n^ \* the License at$\n^ \*[ ]*$\n^ \* http://www\.apache\.org/licenses/LICENSE-2\.0$\n^ \*[ ]*\n \* Unless required by applicable law or agreed to in writing, software( distributed under the License)?$\n^ \* (distributed under the License )?is distributed on an &quot;AS IS&quot; BASIS, WITHOUT( WARRANTIES OR CONDITIONS OF ANY KIND, either express)?$\n^ \* (WARRANTIES OR CONDITIONS OF ANY KIND, either express )?or implied\. See the( License for the specific language governing permissions and limitations under)?$\n^ \* License for the specific language governing permissions and limitations under$\n^ \* the License\.$\n^ \*/$"/>
+       <property name="multiLines" value="6,13"/>
+    </module>
+    <module name="FileTabCharacter">
+        <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="no tabs"/>
+        <property name="fileExtensions" value="java"/>
+        <property name="severity" value="error"/>
+    </module>
+    <module name="TreeWalker">
+       <property name="fileExtensions" value="java"/>
+       <module name="LineLength">
+            <property name="max" value="100"/>
+            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+       </module>
+       <module name="FileContentsHolder" />
+       <module name="InterfaceIsType">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="RedundantImport">
+            <property name="severity" value="error"/>
+        </module>
+        <module name="UnusedImports">
+            <property name="severity" value="error"/>
+        </module>
+        <module name="JavadocType">
+            <property name="severity" value="error"/>
+            <property name="scope" value="protected"/>
+        </module>
+        <module name="PackageName">
+            <property name="severity" value="error"/>
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]{1,})*$"/>
+        </module>
+        <module name="ParameterName">
+            <property name="severity" value="error"/>
+        </module>
+        <module name="LocalFinalVariableName">
+            <property name="severity" value="error"/>
+        </module>
+        <module name="LocalVariableName">
+            <property name="severity" value="error"/>
+            <property name="tokens" value="PARAMETER_DEF,VARIABLE_DEF"/>
+        </module>
+        <module name="LeftCurly"/>
+        <module name="RightCurly"/>
+        <module name="CovariantEquals">
+            <property name="severity" value="error"/>
+        </module>
+        <module name="HiddenField">
+            <property name="severity" value="error"/>
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="ignoreConstructorParameter" value="true"/>
+            <property name="ignoreSetter" value="true"/>
+        </module>
+        <module name="IllegalInstantiation">
+            <property name="severity" value="error"/>
+            <property name="classes" value="java.lang.Boolean"/>
+        </module>
+        <module name="UpperEll">
+            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="checking for 4l rather than 4L"/>
+            <property name="severity" value="error"/>
+        </module>
+        <module name="JavadocStyle">
+            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Well formed java docs"/>
+            <property name="severity" value="info"/>
+            <property name="checkHtml" value="false"/>
+            <property name="tokens" value="CLASS_DEF,CTOR_DEF,INTERFACE_DEF,METHOD_DEF,VARIABLE_DEF"/>
+        </module>
+        <module name="NeedBraces">
+            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="make sure if has braces"/>
+        </module>
+        <module name="JavadocMethod">
+            <metadata name="com.atlassw.tools.eclipse.checkstyle.lastEnabledSeverity" value="info"/>
+            <property name="severity" value="info"/>
+            <property name="scope" value="protected"/>
+            <property name="allowUndeclaredRTE" value="true"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingThrowsTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="allowMissingJavadoc" value="true"/>
+            <property name="allowMissingPropertyJavadoc" value="true"/>
+            <property name="logLoadErrors" value="true"/>
+            <property name="tokens" value="METHOD_DEF"/>
+        </module>
+        <module name="ImportOrder">
+            <property name="severity" value="error"/>
+            <property name="groups" value="com.google, cern, com, junit, net, org, java, javax"/>
+            <property name="ordered" value="true"/>
+            <property name="separated" value="true"/>
+            <property name="option" value="top"/>
+        </module>
+        <module name="DefaultComesLast">
+            <property name="severity" value="error"/>
+        </module>
+        <module name="MultipleStringLiterals">
+            <property name="severity" value="info"/>
+            <property name="ignoreStringsRegexp" value=".{0,3}"/>
+        </module>
+        <module name="FallThrough">
+            <property name="severity" value="error"/>
+        </module>
+        <module name="IllegalInstantiation">
+            <property name="severity" value="error"/>
+            <property name="classes" value="Boolean"/>
+        </module>
+        <module name="Regexp">
+            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="check that a space is left after a colon with an assembled error message"/>
+            <property name="severity" value="info"/>
+            <property name="format" value="[^:^&quot;]:&quot; .*+"/>
+            <property name="message" value="check that a space is left after a colon on an assembled error message"/>
+            <property name="illegalPattern" value="true"/>
+        </module>
+        <module name="Regexp">
+            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="more than one blank line"/>
+            <property name="severity" value="info"/>
+            <property name="format" value="[\r]?[\n][ \t]*[\r]?[\n][ \t]*[\r]?[\n][ \t]*"/>
+            <property name="message" value="more than one blank line"/>
+            <property name="illegalPattern" value="true"/>
+        </module>
+        <module name="WhitespaceAround">
+            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Must have spaces"/>
+            <property name="severity" value="error"/>
+            <property name="tokens" value="COLON,NOT_EQUAL,QUESTION,DIV,DIV_ASSIGN,BXOR,BXOR_ASSIGN,MINUS,LCURLY,STAR,STAR_ASSIGN,TYPE_EXTENSION_AND,BAND,LAND,BAND_ASSIGN,MOD,MOD_ASSIGN,PLUS,PLUS_ASSIGN,LT,SL,SL_ASSIGN,LE,ASSIGN,MINUS_ASSIGN,EQUAL,GT,GE,SR,SR_ASSIGN,BSR,BSR_ASSIGN,BOR,BOR_ASSIGN,LOR,LITERAL_ASSERT,LITERAL_ASSERT,LITERAL_CATCH,LITERAL_DO,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,LITERAL_RETURN,SLIST,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE"/>
+        </module>
+        <module name="Regexp">
+            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="newline before }"/>
+            <property name="severity" value="error"/>
+            <property name="format" value="[\r]?[\n][ \t]*[\r]?[\n][ \t]+[}][ ]*[\n]"/>
+            <property name="message" value="newline before }"/>
+            <property name="illegalPattern" value="true"/>
+        </module>
+        <module name="ModifierOrder">
+            <property name="severity" value="error"/>
+        </module>
+        <module name="AvoidStarImport">
+            <property name="severity" value="error"/>
+        </module>
+        <module name="RegexpSinglelineJava">
+            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="bad // comment"/>
+            <property name="severity" value="error"/>
+            <property name="format" value="  [/][/][A-z]"/>
+            <property name="message" value="// comments must be followed by a space and be on their own line"/>
+        </module>
+        <module name="EmptyStatement">
+            <property name="severity" value="error"/>
+        </module>
+        <module name="MethodName">
+            <property name="severity" value="error"/>
+        </module>
+        <module name="MemberName">
+            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Field names must start with [a-z], may not start with f[A-Z], and should not contain '_''s."/>
+            <property name="severity" value="error"/>
+            <property name="format" value="^([a-eg-z]|(f[a-z0-9]))[a-zA-Z0-9]*$"/>
+        </module>
+        <module name="TodoComment">
+            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Author tags"/>
+            <property name="severity" value="error"/>
+            <property name="format" value="@author"/>
+        </module>
+        <module name="Regexp">
+            <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="No one line javadoc comments"/>
+            <property name="severity" value="error"/>
+            <property name="format" value="[/][*][*][^\n]*[*][/]"/>
+            <property name="message" value="No one line javadoc comments"/>
+            <property name="illegalPattern" value="true"/>
+        </module>
+        <module name="NoWhitespaceAfter">
+            <property name="severity" value="error"/>
+            <property name="allowLineBreaks" value="false"/>
+            <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
+        </module>
+        <module name="WhitespaceAfter">
+            <property name="tokens" value="TYPECAST"/>
+        </module>
+        <module name="TypecastParenPad">
+            <property name="severity" value="error"/>
+            <property name="tokens" value="RPAREN,TYPECAST"/>
+        </module>
+        <module name="ParenPad"/>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceBefore">
+            <property name="severity" value="error"/>
+            <property name="tokens" value="SEMI,POST_DEC,POST_INC"/>
+        </module>
+        <module name="NoWhitespaceBefore">
+            <property name="severity" value="error"/>
+            <property name="allowLineBreaks" value="true"/>
+            <property name="tokens" value="DOT"/>
+        </module>
+        <module name="RedundantModifier"/>
+        <module name="EqualsHashCode"/>
+    </module>
+    <module name="JavadocPackage">
+        <property name="severity" value="ignore"/>
+    </module>
+        <module name="SuppressionCommentFilter">
+       <property name="offCommentFormat" value="CHECKSTYLE_OFF"/>
+       <property name="onCommentFormat" value="CHECKSTYLE_ON"/>
+    </module>
+    <module name="SuppressionCommentFilter">
+       <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Avoid name checking"/>
+      <property name="offCommentFormat" value="CHECKSTYLE_NAMING_OFF"/>
+      <property name="onCommentFormat" value="CHECKSTYLE_NAMING_ON"/>
+      <property name="checkFormat" value="MethodName"/>
+    </module>
+    <module name="SuppressionCommentFilter">
+       <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Avoid name checking"/>
+      <property name="offCommentFormat" value="CHECKSTYLE_NAMING_OFF"/>
+      <property name="onCommentFormat" value="CHECKSTYLE_NAMING_ON"/>
+      <property name="checkFormat" value="MemberName"/>
+    </module>
+    <module name="SuppressionCommentFilter">
+       <metadata name="com.atlassw.tools.eclipse.checkstyle.comment" value="Avoid name checking"/>
+      <property name="offCommentFormat" value="CHECKSTYLE_NAMING_OFF"/>
+      <property name="onCommentFormat" value="CHECKSTYLE_NAMING_ON"/>
+      <property name="checkFormat" value="ParameterName"/>
+    </module>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -27,13 +27,23 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.google.jsinterop</groupId>
+            <artifactId>jsinterop-annotations</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+
+        <!-- As the nature of this project is to move the "xml" module to jsinterop, gwt2 is no longer a dependency -->
+        <dependency>
             <groupId>com.google.gwt</groupId>
             <artifactId>gwt-user</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.gwt</groupId>
             <artifactId>gwt-dev</artifactId>
+            <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -79,14 +89,9 @@
                 <extensions>true</extensions>
                 <configuration>
                     <moduleName>org.gwtproject.xml.XML</moduleName>
-
                     <includes>**/*GwtTest.java</includes>
-
                 </configuration>
-
             </plugin>
-
-
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,21 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>2.14</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                            <consoleOutput>true</consoleOutput>
+                            <failsOnError>true</failsOnError>
+                            <configLocation>checkstyle.xml</configLocation>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
             <plugin>
                 <groupId>net.ltgt.gwt.maven</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
-                <version>1.0-rc-7</version>
+                <version>1.0-rc-9</version>
                 <extensions>true</extensions>
                 <configuration>
                     <moduleName>org.gwtproject.xml.XML</moduleName>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
             <dependency>
                 <groupId>com.google.gwt</groupId>
                 <artifactId>gwt</artifactId>
-                <version>2.8.1</version>
+                <version>2.8.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,16 +58,6 @@
             </plugin>
 
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.6</version>
-                <configuration>
-                    <excludes>
-                        <exclude>**/*GwtTest.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>net.ltgt.gwt.maven</groupId>
                 <artifactId>gwt-maven-plugin</artifactId>
                 <version>1.0-rc-7</version>

--- a/src/test/java/org/gwtproject/xml/client/XMLGwtTest.java
+++ b/src/test/java/org/gwtproject/xml/client/XMLGwtTest.java
@@ -315,7 +315,6 @@ public class XMLGwtTest extends GWTTestCase {
      * At one point, this test was failing on one Safari configuration in
      * Production Mode in the 1.5 release branch.
      */
-    @DoNotRunWith({Platform.HtmlUnitUnknown})
     public void testParse() {
         Document docA = XMLParser.parse("<!--hello-->   <a spam=\"ham\">\n  <?pi hello ?>dfgdfg  <b/>\t</a>");
 


### PR DESCRIPTION
Hey Daniel, I spent a bit of time poking at this project to get it up to date. One of the nice things that can happen is to _not_ depend on gwt 2.x at all, but just use it for tests, making it even more ready for gwt3 (which could have conflicting dependencies). Possible that this could be expressed better in the future, will depend on how a "gwt-maven-plugin" and packaging actually shakes out.

Side note: Since you did the real work here so far, and it looks complete, would you be willing to update the groupId to your own domain name and publish a 1.0 on maven central? If so, people could actually start updating to this and using it in their own projects. Otherwise, I'd be happy to publish it, but wanted to give you the chance to say no first.